### PR TITLE
feat(site): delta-only upgrades (SEO, tags, tag RSS, related, affiliate, workflow fix)

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,11 +4,13 @@
   "scripts": {
     "dev": "astro dev",
     "build": "astro build",
-    "preview": "astro preview"
+    "preview": "astro preview",
+    "prebuild": "node scripts/affiliate_linker.mjs"
   },
   "dependencies": {
     "astro": "^3.0.0",
     "@astrojs/rss": "^3.0.0",
-    "@astrojs/sitemap": "^3.0.0"
+    "@astrojs/sitemap": "^3.0.0",
+    "js-yaml": "^4.1.0"
   }
 }


### PR DESCRIPTION
This PR introduces several delta-only enhancements:

- Adds a `prebuild` script for affiliate linking
- Updates pages.yml to set `ASTRO_BASE` and run prebuild
- Replaces layout and blog page components to include SEO tags, tag RSS, related posts, changelog, and sources
- Adds a default Open Graph image

Please review and merge to enable these improvements.